### PR TITLE
[FEAT] 일일 기록 메모 기능 구현

### DIFF
--- a/how-was-today/how-was-today/App/DI/AppDependencies.swift
+++ b/how-was-today/how-was-today/App/DI/AppDependencies.swift
@@ -23,6 +23,7 @@ final class AppDependencies: DependencyContainer {
     lazy var weightStore: WeightStore = WeightStore(repo: repositories.dailyWeightRepository)
     lazy var moodStore: MoodStore = MoodStore(repo: repositories.dailyMoodRepository)
     lazy var conditionStore: ConditionStore = ConditionStore(repo: repositories.dailyCondiotionRepository)
+    lazy var memoStore: MemoStore = MemoStore(repo: repositories.dailyMemoRepository)
     
     init(repositories: RepositoryContainer) {
         self.repositories = repositories
@@ -55,8 +56,8 @@ extension AppDependencies {
     func makeConditionRecordViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore> {
         ConditionRecordViewModel(date: date, store: conditionStore)
     }
-    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel {
-        MemoRecordViewModel(date: date)
+    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel<MemoStore> {
+        MemoRecordViewModel(date: date, store: memoStore)
     }
 }
 
@@ -84,7 +85,8 @@ extension AppDependencies {
         return FetchDailyRecordUseCaseImpl(
             weightStore: weightStore,
             moodStore: moodStore,
-            conditionStore: conditionStore
+            conditionStore: conditionStore,
+            memoStore: memoStore
         )
     }
 }

--- a/how-was-today/how-was-today/App/DI/AppDependencies.swift
+++ b/how-was-today/how-was-today/App/DI/AppDependencies.swift
@@ -56,7 +56,7 @@ extension AppDependencies {
     func makeConditionRecordViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore> {
         ConditionRecordViewModel(date: date, store: conditionStore)
     }
-    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel<MemoStore> {
+    func makeMemoRecordViewModel(date: Date) -> MemoRecordViewModel<MemoStore> {
         MemoRecordViewModel(date: date, store: memoStore)
     }
 }

--- a/how-was-today/how-was-today/App/DI/AppDependencies.swift
+++ b/how-was-today/how-was-today/App/DI/AppDependencies.swift
@@ -52,9 +52,11 @@ extension AppDependencies {
     func makeMoodRecordBottomSheetViewModel(date: Date) -> MoodRecordBottomSheetViewModel {
         return MoodRecordBottomSheetViewModel(date: date, store: moodStore)
     }
-    
-    func makeConditionRecordBottomSheetViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore> {
+    func makeConditionRecordViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore> {
         ConditionRecordViewModel(date: date, store: conditionStore)
+    }
+    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel {
+        MemoRecordViewModel(date: date)
     }
 }
 

--- a/how-was-today/how-was-today/App/DI/DependencyContainer.swift
+++ b/how-was-today/how-was-today/App/DI/DependencyContainer.swift
@@ -15,12 +15,12 @@ protocol DependencyContainer {
     func makeTodaySummaryViewModel() -> TodaySummaryViewModel
     /// SupplementInput 화면에서 사용할 ViewModel 생성
     func makeSupplementInputViewModel() -> SupplementInputViewModel
-    /// WeightRecord
+    
     func makeWeightRecordViewModel(date: Date) -> WeightRecordBottomSheetViewModel
-    
     func makeMoodRecordBottomSheetViewModel(date: Date) -> MoodRecordBottomSheetViewModel
+    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel
     
-    func makeConditionRecordBottomSheetViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore>
+    func makeConditionRecordViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore>
     
     // MARK: - UseCase
     func makeSupplementUseCaseFactory() -> SupplementUseCaseFactory

--- a/how-was-today/how-was-today/App/DI/DependencyContainer.swift
+++ b/how-was-today/how-was-today/App/DI/DependencyContainer.swift
@@ -19,7 +19,7 @@ protocol DependencyContainer {
     func makeWeightRecordViewModel(date: Date) -> WeightRecordBottomSheetViewModel
     func makeMoodRecordBottomSheetViewModel(date: Date) -> MoodRecordBottomSheetViewModel
     func makeConditionRecordViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore>
-    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel<MemoStore>
+    func makeMemoRecordViewModel(date: Date) -> MemoRecordViewModel<MemoStore>
     
     // MARK: - UseCase
     func makeSupplementUseCaseFactory() -> SupplementUseCaseFactory

--- a/how-was-today/how-was-today/App/DI/DependencyContainer.swift
+++ b/how-was-today/how-was-today/App/DI/DependencyContainer.swift
@@ -18,9 +18,8 @@ protocol DependencyContainer {
     
     func makeWeightRecordViewModel(date: Date) -> WeightRecordBottomSheetViewModel
     func makeMoodRecordBottomSheetViewModel(date: Date) -> MoodRecordBottomSheetViewModel
-    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel
-    
     func makeConditionRecordViewModel(date: Date) -> ConditionRecordViewModel<ConditionStore>
+    func makeMemoRecrodViewModel(date: Date) -> MemoRecordViewModel<MemoStore>
     
     // MARK: - UseCase
     func makeSupplementUseCaseFactory() -> SupplementUseCaseFactory

--- a/how-was-today/how-was-today/Data/DI/RepositoryContainer.swift
+++ b/how-was-today/how-was-today/Data/DI/RepositoryContainer.swift
@@ -39,4 +39,8 @@ final class RepositoryContainer {
     lazy var dailyCondiotionRepository: DailyConditionLogRepository = DailyConditionLogRepositoryImpl(
         storage: RealmStorage<DailyConditionLog>()
     )
+    
+    lazy var dailyMemoRepository: DailyMemoLogRepository = DailyMemoLogRepositoryImpl(
+        storage: RealmStorage<DailyMemoLog>()
+    )
 }

--- a/how-was-today/how-was-today/Data/Models/Realm/DailyMemoLog.swift
+++ b/how-was-today/how-was-today/Data/Models/Realm/DailyMemoLog.swift
@@ -1,0 +1,15 @@
+//
+//  DailyMemoLog.swift
+//  how-was-today
+//
+//  Created by stocktong on 8/22/25.
+//
+
+import RealmSwift
+import Foundation
+
+final class DailyMemoLog: Object {
+    @Persisted(primaryKey: true) var id: String
+    @Persisted var date: Date
+    @Persisted var memo: String // Mood의 rawValue
+}

--- a/how-was-today/how-was-today/Data/Repositories/DailyMemoLogRepository.swift
+++ b/how-was-today/how-was-today/Data/Repositories/DailyMemoLogRepository.swift
@@ -1,0 +1,43 @@
+//
+//  DailyMemoLogRepository.swift
+//  how-was-today
+//
+//  Created by stocktong on 8/22/25.
+//
+
+import Foundation
+
+protocol DailyMemoLogRepository {
+    func fetchMemo(on date: Date) -> String?
+    func saveMemo(on date: Date, _ memo: String) throws
+    func deleteMemo(on date: Date) throws
+}
+
+final class DailyMemoLogRepositoryImpl<Storage: DataStorage>: DailyMemoLogRepository
+where Storage.ObjectType == DailyMemoLog {
+
+    private let storage: Storage
+    init(storage: Storage) { self.storage = storage }
+    
+    func fetchMemo(on date: Date) -> String? {
+        let id = date.toString(format: DailyRecord.dateFormat)
+        let p = NSPredicate(format: "id == %@", id)
+        let one = try? storage.fetch(predicate: p, sortDescriptors: nil)?.first
+        return one?.memo
+    }
+    
+    func saveMemo(on date: Date, _ memo: String) throws {
+        let id = date.toString(format: DailyRecord.dateFormat)
+        let log = DailyMemoLog()
+        log.id = id
+        log.date = date
+        log.memo = memo
+        try storage.save(log)
+    }
+    
+    func deleteMemo(on date: Date) throws {
+        let id = date.toString(format: DailyRecord.dateFormat)
+        let p = NSPredicate(format: "id == %@", id)
+        try storage.deleteAll(predicate: p)
+    }
+}

--- a/how-was-today/how-was-today/Domain/Stores/MemoStore.swift
+++ b/how-was-today/how-was-today/Domain/Stores/MemoStore.swift
@@ -1,0 +1,7 @@
+//
+//  MemoStore.swift
+//  how-was-today
+//
+//  Created by stocktong on 8/22/25.
+//
+

--- a/how-was-today/how-was-today/Domain/Stores/MemoStore.swift
+++ b/how-was-today/how-was-today/Domain/Stores/MemoStore.swift
@@ -5,3 +5,42 @@
 //  Created by stocktong on 8/22/25.
 //
 
+import Foundation
+
+final class MemoStore: ObservableObject, DailyRecordStore {
+    
+    typealias T = String
+    
+    @Published var itemByDate: [String: T] = [:]
+    
+    private let repo: DailyMemoLogRepository
+    
+    init(repo: DailyMemoLogRepository) {
+        self.repo = repo
+    }
+    
+    func refresh(date: Date) {
+        if let memo = repo.fetchMemo(on: date) {
+            itemByDate[key(from: date)] = memo
+        }
+    }
+    
+    func save(_ item: String, on date: Date) {
+        do {
+            try repo.saveMemo(on: date, item)
+            itemByDate[key(from: date)] = item
+        } catch {
+            print("save memo error \(error.localizedDescription)")
+        }
+    }
+    
+    func delete(on date: Date) {
+        do {
+            try repo.deleteMemo(on: date)
+            itemByDate.removeValue(forKey: key(from: date))
+        } catch {
+            print("delete memo error \(error.localizedDescription)")
+        }
+    }
+    
+}

--- a/how-was-today/how-was-today/Domain/UseCases/FetchDailyRecordUseCase.swift
+++ b/how-was-today/how-was-today/Domain/UseCases/FetchDailyRecordUseCase.swift
@@ -17,21 +17,25 @@ struct FetchDailyRecordUseCaseImpl: FetchDailyRecordUseCase {
     private let weightStore: WeightStore
     private let moodStore: MoodStore
     private let conditionStore: ConditionStore
+    private let memoStore: MemoStore
     
     init(
         weightStore: WeightStore,
         moodStore: MoodStore,
-        conditionStore: ConditionStore
+        conditionStore: ConditionStore,
+        memoStore: MemoStore
     ) {
         self.weightStore = weightStore
         self.moodStore = moodStore
         self.conditionStore = conditionStore
+        self.memoStore = memoStore
     }
     
     func refresh(date: Date) {
         weightStore.refresh(date: date)
         moodStore.refresh(date: date)
         conditionStore.refresh(date: date)
+        memoStore.refresh(date: date)
     }
     
     func fetch(date: Date) -> DailyRecord {
@@ -46,6 +50,8 @@ struct FetchDailyRecordUseCaseImpl: FetchDailyRecordUseCase {
             let condition = titles.joined(separator: ", ")
             record.condition = condition
         }
+        record.memo = memoStore.item(on: date)
+        
         return record
     }
 }

--- a/how-was-today/how-was-today/Presentation/Features/DailyRecord/Models/MemoFeature.swift
+++ b/how-was-today/how-was-today/Presentation/Features/DailyRecord/Models/MemoFeature.swift
@@ -15,4 +15,8 @@ struct MemoFeature: DailyRecordFeature {
     var systemImageName: String = "pencil.and.scribble"
     
     var imageColor: Color = Color.orange
+    
+    func getRoute(date: Date) -> HowWasTodayRouter.Route? {
+        .memo(date: date)
+    }
 }

--- a/how-was-today/how-was-today/Presentation/Features/DailyRecord/ViewModels/MemoRecordViewModel.swift
+++ b/how-was-today/how-was-today/Presentation/Features/DailyRecord/ViewModels/MemoRecordViewModel.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
-final class MemoRecordViewModel: ObservableObject {
+final class MemoRecordViewModel<Store: DailyRecordStore>: ObservableObject where Store.T == String {
     
     let date: Date
+    private let store: Store
+    
     @Published var memo: String = ""
     private var original: String = ""
     
@@ -17,8 +19,9 @@ final class MemoRecordViewModel: ObservableObject {
         memo.isEmpty
     }
     
-    init(date: Date) {
+    init(date: Date, store: Store) {
         self.date = date
+        self.store = store
     }
     
     func reset() {
@@ -26,19 +29,30 @@ final class MemoRecordViewModel: ObservableObject {
     }
     
     func refresh() {
-        
+        store.refresh(date: date)
+        fetch()
+    }
+    
+    func fetch() {
+        if let newMemo = store.item(on: date) {
+            memo = newMemo
+            original = newMemo
+        }
     }
     
     func save() {
+        guard isMemoChanged() else { return }
+        
         let trimmed = memo.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             delete()
         } else {
-            // save
+            store.save(memo, on: date)
         }
     }
     
     func delete() {
+        store.delete(on: date)
     }
     
     func isMemoChanged() -> Bool {

--- a/how-was-today/how-was-today/Presentation/Features/DailyRecord/ViewModels/MemoRecordViewModel.swift
+++ b/how-was-today/how-was-today/Presentation/Features/DailyRecord/ViewModels/MemoRecordViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  MemoRecordViewModel.swift
+//  how-was-today
+//
+//  Created by stocktong on 8/20/25.
+//
+
+import Foundation
+
+final class MemoRecordViewModel: ObservableObject {
+    
+    let date: Date
+    @Published var memo: String = ""
+    private var original: String = ""
+    
+    var disableReset: Bool {
+        memo.isEmpty
+    }
+    
+    init(date: Date) {
+        self.date = date
+    }
+    
+    func reset() {
+        memo = ""
+    }
+    
+    func refresh() {
+        
+    }
+    
+    func save() {
+        let trimmed = memo.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            delete()
+        } else {
+            // save
+        }
+    }
+    
+    func delete() {
+    }
+    
+    func isMemoChanged() -> Bool {
+        let trimmed = memo.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed != original
+    }
+}

--- a/how-was-today/how-was-today/Presentation/Features/DailyRecord/Views/MemoRecordView.swift
+++ b/how-was-today/how-was-today/Presentation/Features/DailyRecord/Views/MemoRecordView.swift
@@ -1,0 +1,268 @@
+import SwiftUI
+import UIKit
+
+// MARK: - SwiftUI Entry
+
+struct MemoRecordView: View {
+    @EnvironmentObject var router: HowWasTodayRouter
+    @StateObject private var viewModel: MemoRecordViewModel
+    
+    @State private var showLeaveAlert = false
+
+    init(date: Date, vmFactory: @escaping (Date) -> MemoRecordViewModel) {
+        _viewModel = StateObject(wrappedValue: vmFactory(date))
+    }
+
+    var body: some View {
+        MemoUIKitContainer(
+            text: $viewModel.memo,
+            onSave: { newText in
+                viewModel.memo = newText
+                viewModel.save()
+                router.pop()
+            },
+            onReset: { viewModel.reset() }
+        )
+        .onAppear { viewModel.refresh() }
+        .alert("변경된 내용이 있어요.\n저장할까요?", isPresented: $showLeaveAlert) {
+            Button("아니요", role: .cancel) {
+                router.pop()
+            }
+            Button("저장하기", role: .none) {
+                viewModel.save()
+                router.pop()
+            }
+        }
+        .appNavigationBar(title: "메모", onBack: {
+            if viewModel.isMemoChanged() {
+                showLeaveAlert = true
+            }
+        }, trailing: {
+            Button("초기화") { viewModel.reset() }
+                .font(.subheadline)
+                .foregroundColor(viewModel.disableReset ? .gray : .black)
+                .disabled(viewModel.disableReset)
+        })
+    }
+}
+
+// MARK: - UIKit VC
+
+final class MemoViewController: UIViewController, UITextViewDelegate {
+    
+    private enum Metric {
+        static let minTextViewHeight = 44.0
+        static let maxTextViewHeight = 300.0
+        static let textViewInset = UIEdgeInsets(top: 8.0, left: 0, bottom: 8.0, right: 0)
+        
+        static let buttonRadius = 12.0
+        static let buttonHeight = 50.0
+        
+        static let padding = 20.0
+        static let topPadding = 4.0
+    }
+
+    // External API
+    var text: String = "" {
+        didSet { if textView.text != text { textView.text = text } }
+    }
+    var onSave: ((String) -> Void)?
+    var onChange: ((String) -> Void)?
+    var onReset: (() -> Void)?
+
+    // UI
+    private let stackView = UIStackView()
+    private let textView = UITextView()
+    private let saveButton = UIButton(type: .system)
+    private var textViewHeightConstraint: NSLayoutConstraint!
+
+    // State
+    private var maxTextViewHeight: CGFloat = Metric.maxTextViewHeight
+    private var isKeyboardVisible = false
+
+    // Keyboard observers
+    private var kbShowObserver: NSObjectProtocol?
+    private var kbHideObserver: NSObjectProtocol?
+
+    // MARK: Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupLayout()
+        bindKeyboard()
+        textView.text = text
+    }
+
+    deinit {
+        if let o = kbShowObserver { NotificationCenter.default.removeObserver(o) }
+        if let o = kbHideObserver { NotificationCenter.default.removeObserver(o) }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        calculateMaxHeight()
+        updateTextViewHeight(animated: false) // 첫 레이아웃에서 폭 확정 후 계산
+    }
+
+    // MARK: Layout
+    private func setupLayout() {
+        stackView.axis = .vertical
+        stackView.spacing = 0
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+
+        // TEXTVIEW
+        textView.delegate = self
+        textView.backgroundColor = .clear
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.textContainerInset = Metric.textViewInset
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.tintColor = .main
+        textView.isScrollEnabled = false
+
+        // SAVE BUTTON
+        saveButton.setTitle("저장하기", for: .normal)
+        saveButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        saveButton.setTitleColor(.white, for: .normal)
+        saveButton.backgroundColor = .main
+        saveButton.layer.cornerRadius = Metric.buttonRadius
+        saveButton.layer.masksToBounds = true
+        saveButton.translatesAutoresizingMaskIntoConstraints = false
+        saveButton.addTarget(self, action: #selector(didTapSave), for: .touchUpInside)
+
+        // Flexible spacing
+        let spacer = UIView()
+
+        [textView, spacer, saveButton].forEach { stackView.addArrangedSubview($0) }
+
+        textViewHeightConstraint = textView.heightAnchor.constraint(equalToConstant: Metric.minTextViewHeight)
+        textViewHeightConstraint.isActive = true
+
+        let guide = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: guide.topAnchor, constant: Metric.topPadding),
+            stackView.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: Metric.padding),
+            stackView.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -Metric.padding),
+            stackView.bottomAnchor.constraint(equalTo: guide.bottomAnchor, constant: -Metric.padding),
+
+            spacer.heightAnchor.constraint(greaterThanOrEqualToConstant: Metric.padding),
+            saveButton.heightAnchor.constraint(equalToConstant: Metric.buttonHeight)
+        ])
+    }
+
+    private func calculateMaxHeight() {
+        let safeH = view.safeAreaLayoutGuide.layoutFrame.height
+        // top(4)+bottom(20)=24, spacer 최소 20, 버튼 50 (키보드 있을 땐 버튼 숨김)
+        let chrome: CGFloat = Metric.topPadding + (Metric.padding * 2) + (isKeyboardVisible ? 0 : Metric.buttonHeight)
+        let available = max(100, safeH - chrome) // 하한선 방어
+        maxTextViewHeight = available
+    }
+
+    private func contentFittingHeight(for width: CGFloat) -> CGFloat {
+        // 폭이 0일 수 있어 방어
+        let w = max(1, width)
+        let fitting = textView.sizeThatFits(CGSize(width: w, height: .greatestFiniteMagnitude))
+        return max(Metric.minTextViewHeight, fitting.height)
+    }
+
+    private func updateTextViewHeight(animated: Bool = true) {
+        let target = contentFittingHeight(for: textView.bounds.width)
+        if target <= maxTextViewHeight {
+            textView.isScrollEnabled = false
+            textViewHeightConstraint.constant = target
+        } else {
+            textView.isScrollEnabled = true
+            textViewHeightConstraint.constant = maxTextViewHeight
+        }
+        if animated {
+            UIView.animate(withDuration: 0.1) { self.view.layoutIfNeeded() }
+        } else {
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    // MARK: Keyboard
+    private func bindKeyboard() {
+        kbShowObserver = NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            isKeyboardVisible = true
+            saveButton.isHidden = true
+            calculateMaxHeight()
+            updateTextViewHeight()
+        }
+
+        kbHideObserver = NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            isKeyboardVisible = false
+            saveButton.isHidden = false
+            calculateMaxHeight()
+            updateTextViewHeight()
+        }
+    }
+
+    // MARK: Actions
+    @objc private func didTapSave() {
+        onSave?(textView.text)
+    }
+
+    // MARK: UITextViewDelegate
+    func textViewDidChange(_ tv: UITextView) {
+        text = tv.text
+        onChange?(tv.text)
+        updateTextViewHeight()
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+}
+
+// MARK: - SwiftUI Bridge
+
+struct MemoUIKitContainer: UIViewControllerRepresentable {
+    
+    @Binding var text: String
+    var onSave: (String) -> Void
+    var onReset: () -> Void = {}
+    
+    final class Coordinator {
+        var text: Binding<String>
+        init(text: Binding<String>) { self.text = text }
+        func textChanged(_ new: String) {
+            if text.wrappedValue != new {
+                text.wrappedValue = new   // ← SwiftUI State/VM로 반영
+            }
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeUIViewController(context: Context) -> MemoViewController {
+        let vc = MemoViewController()
+        vc.text = text
+        vc.onSave = { [weak vc] newText in
+            onSave(newText)
+            // (선택) 저장 후 키보드 닫기/해제
+            vc?.view.endEditing(true)
+        }
+        vc.onReset = { [weak vc] in
+            onReset()
+            vc?.text = ""
+            vc?.view.endEditing(true)
+        }
+        vc.onChange = { context.coordinator.textChanged($0) }
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: MemoViewController, context: Context) {
+        if uiViewController.text != text {
+            uiViewController.text = text
+        }
+    }
+}

--- a/how-was-today/how-was-today/Presentation/Features/DailyRecord/Views/MemoRecordView.swift
+++ b/how-was-today/how-was-today/Presentation/Features/DailyRecord/Views/MemoRecordView.swift
@@ -5,11 +5,11 @@ import UIKit
 
 struct MemoRecordView: View {
     @EnvironmentObject var router: HowWasTodayRouter
-    @StateObject private var viewModel: MemoRecordViewModel
+    @StateObject private var viewModel: MemoRecordViewModel<MemoStore>
     
     @State private var showLeaveAlert = false
 
-    init(date: Date, vmFactory: @escaping (Date) -> MemoRecordViewModel) {
+    init(date: Date, vmFactory: @escaping (Date) -> MemoRecordViewModel<MemoStore>) {
         _viewModel = StateObject(wrappedValue: vmFactory(date))
     }
 

--- a/how-was-today/how-was-today/Presentation/Features/DailyRecord/Views/MemoRecordView.swift
+++ b/how-was-today/how-was-today/Presentation/Features/DailyRecord/Views/MemoRecordView.swift
@@ -36,6 +36,8 @@ struct MemoRecordView: View {
         .appNavigationBar(title: "메모", onBack: {
             if viewModel.isMemoChanged() {
                 showLeaveAlert = true
+            } else {
+                router.pop()
             }
         }, trailing: {
             Button("초기화") { viewModel.reset() }

--- a/how-was-today/how-was-today/Presentation/Features/SupplementInput/Views/SupplementInputView.swift
+++ b/how-was-today/how-was-today/Presentation/Features/SupplementInput/Views/SupplementInputView.swift
@@ -97,12 +97,3 @@ struct SupplementInputView: View {
         }
     }
 }
-
-extension View {
-    func endEditing() {
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.resignFirstResponder),
-            to: nil, from: nil, for: nil
-        )
-    }
-}

--- a/how-was-today/how-was-today/Presentation/Router/Router.swift
+++ b/how-was-today/how-was-today/Presentation/Router/Router.swift
@@ -117,7 +117,7 @@ extension HowWasTodayRouter: Router {
             ).id(date)
         case .memo(let date):
             MemoRecordView(date: date, vmFactory: { _ in
-                dep.makeMemoRecrodViewModel(date: date)
+                dep.makeMemoRecordViewModel(date: date)
             }
             ).id(date)
         }

--- a/how-was-today/how-was-today/Presentation/Router/Router.swift
+++ b/how-was-today/how-was-today/Presentation/Router/Router.swift
@@ -58,6 +58,7 @@ final class HowWasTodayRouter: ObservableObject {
         case todaySummary
         case inputSupplement
         case condition(date: Date)
+        case memo(date: Date)
     }
     
     enum Modal: Hashable, Identifiable {
@@ -104,15 +105,20 @@ extension HowWasTodayRouter: Router {
         let dep = self.dependencies
         switch route {
         case .todaySummary:
-            TodaySummaryView(viewModelFactory: self.dependencies.makeTodaySummaryViewModel)
+            TodaySummaryView(viewModelFactory: dep.makeTodaySummaryViewModel)
         case .inputSupplement:
-            SupplementInputView(viewModelFactory: dependencies.makeSupplementInputViewModel)
+            SupplementInputView(viewModelFactory: dep.makeSupplementInputViewModel)
         case .condition(let date):
             ConditionRecordView(
                 date: date,
                 viewModelFactory: { _ in
-                    dep.makeConditionRecordBottomSheetViewModel(date: date)
+                    dep.makeConditionRecordViewModel(date: date)
                 }
+            ).id(date)
+        case .memo(let date):
+            MemoRecordView(date: date, vmFactory: { _ in
+                dep.makeMemoRecrodViewModel(date: date)
+            }
             ).id(date)
         }
     }

--- a/how-was-today/how-was-today/Shared/Extensions/Color+.swift
+++ b/how-was-today/how-was-today/Shared/Extensions/Color+.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 extension Color {
     static let main = Color(hex: "#5EC3E8")
@@ -16,4 +17,8 @@ extension Color {
     // icon tint color
     static let supplement = Color(hex: "#A3DB91")
     static let health =  Color(hex: "#756355")
+}
+
+extension UIColor {
+    static let main = UIColor(hex: "#5EC3E8")
 }

--- a/how-was-today/how-was-today/Shared/Extensions/Color+HexColor.swift
+++ b/how-was-today/how-was-today/Shared/Extensions/Color+HexColor.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 extension Color {
     init(hex: String) {
@@ -41,5 +42,35 @@ extension Color {
             blue: Double(b) / 255,
             opacity: Double(a) / 255
         )
+    }
+}
+
+extension UIColor {
+    convenience init?(hex: String, alpha: CGFloat = 1.0) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+        let length = hexSanitized.count
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
+
+        switch length {
+        case 6: // RRGGBB
+            let r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+            let g = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+            let b = CGFloat(rgb & 0x0000FF) / 255.0
+            self.init(red: r, green: g, blue: b, alpha: alpha)
+
+        case 8: // RRGGBBAA
+            let r = CGFloat((rgb & 0xFF000000) >> 24) / 255.0
+            let g = CGFloat((rgb & 0x00FF0000) >> 16) / 255.0
+            let b = CGFloat((rgb & 0x0000FF00) >> 8) / 255.0
+            let a = CGFloat(rgb & 0x000000FF) / 255.0
+            self.init(red: r, green: g, blue: b, alpha: a)
+
+        default:
+            return nil
+        }
     }
 }

--- a/how-was-today/how-was-today/Shared/Extensions/View+Keyboard.swift
+++ b/how-was-today/how-was-today/Shared/Extensions/View+Keyboard.swift
@@ -1,0 +1,16 @@
+//
+//  View+Keyboard.swift
+//  how-was-today
+//
+//  Created by stocktong on 8/20/25.
+//
+
+import SwiftUI
+extension View {
+    func endEditing() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+    }
+}


### PR DESCRIPTION
#16 

  ## Summary
  • 일일 기록에 메모 기능 추가 구현
  • 메모 작성/수정/저장 비즈니스 로직 구현
  • 변경사항 없을 시 백버튼 액션 처리 개선

  ## Changes
  - `MemoRecordView` - 메모 입력 UI 구현
  - `MemoRecordViewModel` - 메모 관리 비즈니스 로직
  - `DailyMemoLogRepository` - 메모 데이터 저장/조회
  - `MemoStore` - 메모 상태 관리
  - 메모 변경사항 검증 및 백버튼 액션 처리